### PR TITLE
Create game intro and choices

### DIFF
--- a/Consequence.java
+++ b/Consequence.java
@@ -1,0 +1,452 @@
+import java.util.*;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+
+/**
+ * CONSEQUENCE (Console Edition, Java)
+ * Endings-first narrative engine with a compact, readable scene graph.
+ * - Time UI is separate from story text (Day/Hour header each turn)
+ * - Max 4 choices per scene
+ * - Six endings: Saint, Tyrant, Ghost, Manipulator, Lone Survivor, Bloomborne
+ */
+public class Consequence {
+	public static void main(String[] args) {
+		NarrativeEngine engine = new NarrativeEngine();
+		engine.run();
+	}
+}
+
+class NarrativeEngine {
+	private final Map<String, Scene> idToScene = new LinkedHashMap<>();
+	private final List<Ending> endings = new ArrayList<>();
+	private final GameState state = new GameState();
+	private final Scanner scanner = new Scanner(System.in);
+
+	public NarrativeEngine() {
+		buildEndings();
+		buildScenes();
+	}
+
+	public void run() {
+		println("=== CONSEQUENCE (Java Console) ===");
+		println("Controls: enter a number 1-4 to choose; q exits.");
+		goTo("intro");
+		while (true) {
+			Scene scene = idToScene.get(state.currentSceneId);
+			if (scene == null) {
+				println("[Engine] Missing scene: " + state.currentSceneId + ". Ending now.");
+				renderEnding(pickEnding());
+				return;
+			}
+			printStatusLine();
+			println(scene.text);
+			List<Choice> choices = scene.choices.size() > 4 ? scene.choices.subList(0, 4) : scene.choices;
+			for (int i = 0; i < choices.size(); i++) {
+				println("  " + (i + 1) + ") " + choices.get(i).text);
+			}
+			print("Choose [1-" + choices.size() + "] or q: ");
+			String input = scanner.nextLine().trim();
+			if (input.equalsIgnoreCase("q")) {
+				println("Exiting.");
+				return;
+			}
+			int idx;
+			try { idx = Integer.parseInt(input) - 1; } catch (Exception e) { println("Invalid."); continue; }
+			if (idx < 0 || idx >= choices.size()) { println("Out of range."); continue; }
+			selectChoice(choices.get(idx));
+			if ("THE_END".equals(state.currentSceneId)) {
+				renderEnding(pickEnding());
+				return;
+			}
+		}
+	}
+
+	private void buildEndings() {
+		endings.add(new Ending(
+			"ending_bloomborne",
+			"Bloomborne",
+			"You listened to the whisper until it answered back. Filaments under skin. You became the song the city hums.",
+			s -> s.flags.contains("bloomChoice")
+		));
+		endings.add(new Ending(
+			"ending_tyrant",
+			"Tyrant of the Block",
+			"You seized control and carved order from fear. Survivors live, but flinch when floorboards creak.",
+			s -> s.morality <= -45 && s.trauma < 80
+		));
+		endings.add(new Ending(
+			"ending_manipulator",
+			"Smiling Knives",
+			"Debts, favors, secrets—your web held the city. No one can point to a weapon, only to your smile.",
+			s -> s.flags.contains("manipulator")
+		));
+		endings.add(new Ending(
+			"ending_ghost",
+			"The Ghost in the Vents",
+			"You vanished between walls and rooftops. A rumor with a heartbeat.",
+			s -> s.flags.contains("stalker")
+		));
+		endings.add(new Ending(
+			"ending_saint",
+			"Saint of Ashes",
+			"You spent yourself saving the broken. Mercy cost you much, but the world remembers kindness.",
+			s -> s.morality >= 45
+		));
+		endings.add(new Ending(
+			"ending_lone_survivor",
+			"Alone On Purpose",
+			"You chose yourself over the many. In the quiet, you learned the shape of your own shadow.",
+			s -> s.flags.contains("loneWolf")
+		));
+	}
+
+	private void buildScenes() {
+		// Intro - Alex at the door. Core premise.
+		scene("intro",
+			"A low, desperate pounding rattles your door. Alex—your neighbor—pleads: 'Please. I got bit.' The hall reeks of disinfectant and wet mold.",
+			choices(
+				choice("help_alex", "Unbolt the door and help Alex inside", eff(+6, 0, +4), go("alex_inside")),
+				choice("stay_silent", "Stay silent and hold your breath", eff(-4, 0, +2), go("silence_wait")),
+				choice("probe", "Talk through the door—test what he admits", eff(0, 0, 0), go("interrogate_alex")),
+				choice("window_escape", "Climb out the window to the fire escape", eff(0, 0, +6), go("alley_drop"))
+			)
+		);
+
+		scene("alex_inside",
+			"Alex stumbles in. The bite is a crescent of purpled teeth. He's shaking. 'Don't let me turn.'",
+			choices(
+				choice("treat", "Clean and dress the wound; keep him calm", eff(0, +5, 0), go("treat_wound")),
+				choice("bind", "Tie him to a chair 'for safety'", eff(-2, 0, 0), go("bind_alex")),
+				choice("exploit", "Promise help if he signs over supplies", eff(0, 0, 0), go("exploit_alex")).after(s -> s.flags.add("manipulator")),
+				choice("mercy_kill", "Whisper an apology and end it quickly", eff(-12, +12, 0), go("mercy_kill_alex"))
+			)
+		);
+
+		scene("silence_wait",
+			"The pounding fades. Steps drag down the stairs. You count to one hundred before lungs beg for air.",
+			choices(
+				choice("follow", "Shadow him at a distance", eff(0, 0, 0), go("stalker_tail")).after(s -> s.flags.add("stalker")),
+				choice("barricade", "Reinforce the door and take stock", eff(0, 0, -4), go("room_inventory")),
+				choice("late_call", "Call out—too late—and hear nothing", eff(-1, 0, 0), go("room_inventory")),
+				choice("window_exit", "Slip out the window after him", eff(0, 0, 0), go("alley_drop"))
+			)
+		);
+
+		scene("interrogate_alex",
+			"'What happened?' you ask through the door. He sobs about a stairwell ambush and a nest that sings under maintenance lights.",
+			choices(
+				choice("negotiate", "Offer help in exchange for his keys", eff(0, 0, 0), go("exploit_alex_from_door")).after(s -> s.flags.add("manipulator")),
+				choice("warn_off", "Tell him to leave before others hear", eff(-3, 0, 0), go("silence_wait")),
+				choice("let_in", "Open up after all", eff(+3, 0, 0), go("alex_inside")),
+				choice("record", "Record his promises for leverage", eff(0, 0, 0), go("room_inventory")).after(s -> s.flags.add("manipulator"))
+			)
+		);
+
+		scene("alley_drop",
+			"You lower yourself to the fire escape. A rung slick with algae slides. You land hard; filaments shimmer in puddles.",
+			choices(
+				choice("scavenge", "Scavenge the dumpsters", eff(0, 0, 0), go("find_cache")),
+				choice("leave_city", "Head toward the river alone", eff(0, 0, 0), go("lone_walk")).after(s -> s.flags.add("loneWolf")),
+				choice("listen", "Listen to the distant hum—the Bloom's song", eff(0, 0, 0), go("bloom_listen")),
+				choice("circle_back", "Circle back to the lobby entrance", eff(0, 0, 0), go("lobby_crossroads"))
+			)
+		);
+
+		scene("treat_wound",
+			"You boil water, clean the bite, keep Alex talking. He laughs once—thin—and thanks you. Fever climbs.",
+			choices(
+				choice("stay_with", "Stay with him through the night", eff(+4, 0, +3), go("care_night")),
+				choice("seek_help", "Go find antibiotics at the pharmacy", eff(0, 0, 0), go("pharmacy_run")),
+				choice("plan_escape", "Plan evacuation for both of you", eff(0, 0, 0), go("evac_plan")),
+				choice("test_light", "Test the wound under a pulsing lamp", eff(0, 0, 0), go("bloom_test"))
+			)
+		);
+
+		scene("bind_alex",
+			"Rope bites his wrists. 'Just until we're sure,' you say. His eyes don't leave your hands.",
+			choices(
+				choice("comfort", "Offer water and a story", eff(+1, 0, 0), go("treat_wound")),
+				choice("interrogate", "Ask about his supplies and contacts", eff(0, 0, 0), go("exploit_alex")).after(s -> s.flags.add("manipulator")),
+				choice("threaten", "Remind him who has the knife", eff(-5, +2, 0), go("extract_tribute")).after(s -> s.flags.add("manipulator")),
+				choice("leave_bound", "Leave him and go loot", eff(-6, 0, 0), go("find_cache"))
+			)
+		);
+
+		scene("exploit_alex",
+			"Alex has pantry keys, generator fuel, neighbors who trust him. He'll trade anything for hope.",
+			choices(
+				choice("paper_sign", "Make him sign an IOU for half his stash", eff(0, 0, 0), go("paper_signed")).after(s -> s.flags.add("manipulator")),
+				choice("lie_cure", "Lie about a cure to secure obedience", eff(-8, 0, 0), go("paper_signed")).after(s -> s.flags.add("manipulator")),
+				choice("relent", "Help without strings", eff(+6, 0, 0), go("treat_wound")),
+				choice("sell_out", "Call the Purifiers and sell his location", eff(-10, +4, 0), go("route_purifiers")).after(s -> s.flags.add("manipulator"))
+			)
+		);
+
+		scene("exploit_alex_from_door",
+			"Through the wood you barter. Keys slide under the gap, his hands trembling.",
+			choices(
+				choice("take_keys", "Take keys and send him away", eff(-6, 0, 0), go("room_inventory")).after(s -> s.flags.add("manipulator")),
+				choice("open_after", "Open the door now that you have leverage", eff(0, 0, 0), go("alex_inside")),
+				choice("keep_recording", "Keep recording every promise", eff(0, 0, 0), go("room_inventory")).after(s -> s.flags.add("manipulator")),
+				choice("apologize", "Apologize and refuse the trade", eff(+2, 0, 0), go("silence_wait"))
+			)
+		);
+
+		scene("mercy_kill_alex",
+			"You do not miss. The room rings. The Bloom hum answers from the walls like distant rain.",
+			choices(
+				choice("wipe_blade", "Wipe the blade and breathe", eff(0, 0, 0), go("room_inventory")),
+				choice("leave_now", "Leave before the neighbors come", eff(0, 0, 0), go("alley_drop")),
+				choice("sit", "Sit with him until the room stops spinning", eff(0, +6, 0), go("room_inventory")),
+				choice("call_purifiers", "Call Purifiers to claim bounty", eff(-6, 0, 0), go("route_purifiers"))
+			)
+		);
+
+		scene("stalker_tail",
+			"You move like a rumor. Alex limps toward the lobby, stopping to cough pink.",
+			choices(
+				choice("shadow_more", "Shadow him to the street", eff(0, 0, 0), go("lobby_crossroads")).after(s -> s.flags.add("stalker")),
+				choice("pick_pocket", "Lift his wallet on the landing", eff(-2, 0, 0), go("room_inventory")),
+				choice("mark_route", "Note Bloom clusters he avoids", eff(0, 0, 0), go("bloom_listen")),
+				choice("abort", "Return home, unheard", eff(0, 0, 0), go("room_inventory"))
+			)
+		);
+
+		scene("find_cache",
+			"Behind a loose brick, a cache: bandages, two protein bars, a strange tuning fork etched with circles.",
+			choices(
+				choice("take_all", "Take everything and move on", eff(0, 0, -2), go("lobby_crossroads")),
+				choice("leave_some", "Leave one bar for whoever comes next", eff(+2, 0, 0), go("lobby_crossroads")),
+				choice("study_fork", "Strike the fork and listen to the walls", eff(0, 0, 0), go("bloom_listen")),
+				choice("stash", "Create a new stash elsewhere", eff(0, 0, 0), go("lone_walk")).after(s -> s.flags.add("loneWolf"))
+			)
+		);
+
+		scene("bloom_test",
+			"Under pulsing light the veins contract, then reach. The Bloom hates some frequencies—and loves others.",
+			choices(
+				choice("note_science", "Record frequencies that repel it", eff(0, 0, 0), go("room_inventory")).after(s -> s.flags.add("bloomInsight")),
+				choice("note_ecstasy", "Record frequencies that make it sing", eff(0, 0, 0), go("room_inventory")).after(s -> { s.flags.add("bloomChoice"); s.flags.add("bloomInsight"); }),
+				choice("do_nothing", "Turn off the light and pretend you saw nothing", eff(0, 0, 0), go("room_inventory")),
+				choice("panic", "Panic and step away", eff(0, +4, 0), go("room_inventory"))
+			)
+		);
+
+		scene("bloom_listen",
+			"You press the tuning fork to the railing. In the metal, a chord blooms—low, tender, hungry.",
+			choices(
+				choice("resist", "Resist the harmony; memorize its shape", eff(0, 0, 0), go("lobby_crossroads")).after(s -> s.flags.add("bloomInsight")),
+				choice("answer", "Hum back until your teeth vibrate", eff(0, -4, 0), go("finale_bridge")).after(s -> s.flags.add("bloomChoice")),
+				choice("smash", "Smash the fork and move on", eff(0, 0, 0), go("lobby_crossroads")),
+				choice("keep", "Pocket the fork for later", eff(0, 0, 0), go("lobby_crossroads"))
+			)
+		);
+
+		scene("lobby_crossroads",
+			"In the lobby: a barricaded door to the street, a pharmacy sign across the avenue, and Purifier graffiti: WE BURN WHAT SINGS.",
+			choices(
+				choice("pharmacy", "Dash to the pharmacy for meds", eff(0, 0, 0), go("pharmacy_run")),
+				choice("purifiers", "Approach the Purifier checkpoint", eff(0, 0, 0), go("route_purifiers")),
+				choice("back_upstairs", "Return upstairs to Alex", eff(0, 0, 0), go("alex_inside")),
+				choice("river", "Head toward the river alone", eff(0, 0, 0), go("lone_walk")).after(s -> s.flags.add("loneWolf"))
+			)
+		);
+
+		scene("pharmacy_run",
+			"Shadows crowd the aisles. You grab antibiotics and gauze. Something rustles above the ceiling tiles.",
+			choices(
+				choice("sneak", "Sneak out the back with what you can carry", eff(0, 0, +2), go("finale_bridge")),
+				choice("help_stranger", "A stranger hisses for help—help them", eff(+5, 0, 0), go("finale_bridge")),
+				choice("bait", "Toss a bottle to lure the nest away and bolt", eff(0, 0, 0), go("finale_bridge")),
+				choice("torch", "Set the ceiling on fire and run", eff(-6, +3, 0), go("finale_bridge")).after(s -> s.flags.add("manipulator"))
+			)
+		);
+
+		scene("route_purifiers",
+			"Red armbands and welded steel. A loudspeaker cracks: 'Declare yourself.'",
+			choices(
+				choice("volunteer", "Volunteer intel on Bloom nests", eff(-2, 0, 0), go("finale_bridge")).after(s -> s.flags.add("manipulator")),
+				choice("trade", "Trade meds for access", eff(0, 0, 0), go("finale_bridge")),
+				choice("double_cross", "Feed them Alex's address and walk away", eff(-10, 0, 0), go("finale_bridge")).after(s -> s.flags.add("manipulator")),
+				choice("withdraw", "Back away before they mark you", eff(0, 0, 0), go("finale_bridge"))
+			)
+		);
+
+		scene("lone_walk",
+			"Alone, the city is a map of risks you can carry in your head. No promises. No witnesses.",
+			choices(
+				choice("keep_moving", "Keep moving toward the water", eff(0, 0, 0), go("finale_bridge")).after(s -> s.flags.add("loneWolf")),
+				choice("return", "Turn back one last time", eff(0, 0, 0), go("finale_bridge")),
+				choice("stash_more", "Make hidden stashes along the way", eff(0, 0, 0), go("finale_bridge")).after(s -> s.flags.add("loneWolf")),
+				choice("follow_song", "Follow the song only you hear", eff(0, 0, 0), go("bloom_listen"))
+			)
+		);
+
+		scene("paper_signed",
+			"The paper is a promise with teeth. Alex signs with a shaking hand.",
+			choices(
+				choice("cash_in", "Collect now and leave him to fate", eff(-6, 0, 0), go("finale_bridge")).after(s -> s.flags.add("manipulator")),
+				choice("change_heart", "Tear it up and actually help", eff(+5, 0, 0), go("treat_wound")),
+				choice("leverage", "Use it to bend the block to your will", eff(0, 0, 0), go("finale_bridge")).after(s -> s.flags.add("manipulator")),
+				choice("sell_purifiers", "Sell the debt to the Purifiers", eff(-8, 0, 0), go("route_purifiers")).after(s -> s.flags.add("manipulator"))
+			)
+		);
+
+		scene("evac_plan",
+			"You map rooftops and alleys. With luck you and Alex can reach the ferry by dusk.",
+			choices(
+				choice("depart_now", "Depart now while streets are thin", eff(0, 0, 0), go("finale_bridge")),
+				choice("wait", "Wait for night and try in the dark", eff(0, 0, +2), go("finale_bridge")),
+				choice("abandon", "Leave him sleeping and travel faster", eff(-7, 0, 0), go("finale_bridge")).after(s -> s.flags.add("loneWolf")),
+				choice("call_help", "Radio anyone who still answers", eff(0, 0, 0), go("finale_bridge"))
+			)
+		);
+
+		scene("finale_bridge",
+			"Hours later, choices have a shape. The city listens. The Bloom hums its one long note.",
+			choices(
+				choice("accept_fate", "Face what you've become", eff(0, 0, 0), go("THE_END")),
+				choice("one_more_good", "Do one more good deed on the way", eff(+2, 0, 0), go("THE_END")),
+				choice("one_more_terrible", "Do one more terrible thing to feel in control", eff(-4, 0, 0), go("THE_END")),
+				choice("listen_song", "Listen again to the song under everything", eff(0, 0, 0), go("THE_END")).after(s -> { if (!s.flags.contains("bloomChoice") && s.flags.contains("bloomInsight")) s.flags.add("bloomChoice"); })
+			)
+		);
+	}
+
+	private void selectChoice(Choice choice) {
+		applyEffects(choice);
+		if (choice.afterEffect != null) choice.afterEffect.accept(state);
+		advanceTime(1);
+		goTo(choice.goToSceneId);
+	}
+
+	private void applyEffects(Choice choice) {
+		if (choice.deltaMorality != 0) state.morality = clamp(state.morality + choice.deltaMorality, -100, 100);
+		if (choice.deltaTrauma != 0) state.trauma = clamp(state.trauma + choice.deltaTrauma, 0, 100);
+		if (choice.deltaStress != 0) state.stress = clamp(state.stress + choice.deltaStress, 0, 100);
+	}
+
+	private void goTo(String sceneId) {
+		state.currentSceneId = sceneId;
+		Scene s = idToScene.get(sceneId);
+		if (s != null && s.onEnter != null) s.onEnter.accept(state);
+	}
+
+	private void renderEnding(Ending ending) {
+		println("");
+		println("=== THE END ===");
+		println(ending.title);
+		println("");
+		println(ending.text);
+	}
+
+	private Ending pickEnding() {
+		for (Ending e : endings) {
+			if (e.criteria.test(state)) return e;
+		}
+		return endings.stream().filter(e -> e.id.equals("ending_lone_survivor")).findFirst().orElse(endings.get(endings.size()-1));
+	}
+
+	private void printStatusLine() {
+		String hourStr = String.format("%02d", state.hour);
+		println("");
+		println("Day " + state.day + ", " + hourStr + ":00  |  Morality " + state.morality + "  Trauma " + state.trauma + "  Stress " + state.stress);
+	}
+
+	private void advanceTime(int hours) {
+		int total = state.hour + Math.max(0, hours);
+		while (total >= 24) { total -= 24; state.day += 1; }
+		state.hour = total;
+	}
+
+	// Scene/Choice DSL helpers
+	private void scene(String id, String text, List<Choice> choices) {
+		Scene s = new Scene(id, text, null, choices);
+		idToScene.put(id, s);
+	}
+
+	@SuppressWarnings("unused")
+	private void scene(String id, String text, Consumer<GameState> onEnter, List<Choice> choices) {
+		Scene s = new Scene(id, text, onEnter, choices);
+		idToScene.put(id, s);
+	}
+
+	private List<Choice> choices(Choice... list) { return new ArrayList<>(Arrays.asList(list)); }
+
+	private Choice choice(String id, String text, int[] eff, String goTo) { return new Choice(id, text, eff[0], eff[1], eff[2], goTo, null); }
+
+	private Choice choice(String id, String text, int[] eff, Go go) { return new Choice(id, text, eff[0], eff[1], eff[2], go.sceneId, null); }
+
+	private int[] eff(int morality, int trauma, int stress) { return new int[]{ morality, trauma, stress }; }
+
+	private Go go(String sceneId) { return new Go(sceneId); }
+
+	// Printing utilities
+	private void println(String s) { System.out.println(s); }
+	private void print(String s) { System.out.print(s); }
+
+	// Inner helper types
+	private static class Go { final String sceneId; Go(String s) { this.sceneId = s; } }
+}
+
+class GameState {
+	int day = 0;
+	int hour = 8;
+	int morality = 0; // -100..100
+	int trauma = 10; // 0..100
+	int stress = 10; // 0..100
+	String currentSceneId = "intro";
+	Set<String> flags = new LinkedHashSet<>();
+
+	static int clamp(int value, int min, int max) { return Math.max(min, Math.min(max, value)); }
+}
+
+class Scene {
+	final String id;
+	final String text;
+	final Consumer<GameState> onEnter;
+	final List<Choice> choices;
+
+	Scene(String id, String text, Consumer<GameState> onEnter, List<Choice> choices) {
+		this.id = id;
+		this.text = text;
+		this.onEnter = onEnter;
+		this.choices = choices == null ? new ArrayList<>() : choices;
+	}
+}
+
+class Choice {
+	final String id;
+	final String text;
+	final int deltaMorality;
+	final int deltaTrauma;
+	final int deltaStress;
+	final String goToSceneId;
+	Consumer<GameState> afterEffect;
+
+	Choice(String id, String text, int dM, int dT, int dS, String goToSceneId, Consumer<GameState> after) {
+		this.id = id;
+		this.text = text;
+		this.deltaMorality = dM;
+		this.deltaTrauma = dT;
+		this.deltaStress = dS;
+		this.goToSceneId = goToSceneId;
+		this.afterEffect = after;
+	}
+
+	Choice after(Consumer<GameState> c) { this.afterEffect = c; return this; }
+}
+
+class Ending {
+	final String id;
+	final String title;
+	final String text;
+	final Predicate<GameState> criteria;
+
+	Ending(String id, String title, String text, Predicate<GameState> criteria) {
+		this.id = id;
+		this.title = title;
+		this.text = text;
+		this.criteria = criteria;
+	}
+}

--- a/mystory.html
+++ b/mystory.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>CONSEQUENCE - A Post-Apocalyptic Text Adventure</title>
-    <link rel="stylesheet" href="styles.css">
+    <link rel="stylesheet" href="MYSTORY.CSS">
     <style>
         /* Additional epic styles */
         @import url('https://fonts.googleapis.com/css2?family=Creepster&family=Special+Elite&display=swap');

--- a/script_5MB_FIXED.js
+++ b/script_5MB_FIXED.js
@@ -1,0 +1,470 @@
+/* CONSEQUENCE Narrative Engine (Endings-first)
+   This file replaces ad-hoc story blobs with a clean scene graph engine.
+   UI uses existing elements in mystory.html: #scene-container, #scene-text, #choices, #stats, #inventory, #log
+*/
+
+(function () {
+	"use strict";
+
+	const STORAGE_KEY = "consequence-save-v2";
+
+	function clamp(value, min, max) {
+		return Math.max(min, Math.min(max, value));
+	}
+
+	function createElement(tag, props, ...children) {
+		const el = document.createElement(tag);
+		if (props) {
+			Object.entries(props).forEach(([key, val]) => {
+				if (key === "class") el.className = val;
+				else if (key === "dataset") Object.assign(el.dataset, val);
+				else if (key.startsWith("on") && typeof val === "function") el.addEventListener(key.substring(2), val);
+				else if (val !== undefined && val !== null) el.setAttribute(key, String(val));
+			});
+		}
+		for (const child of children.flat()) {
+			if (child === undefined || child === null) continue;
+			if (child instanceof Node) el.appendChild(child);
+			else el.appendChild(document.createTextNode(String(child)));
+		}
+		return el;
+	}
+
+	// Endings-first: define canonical endings up-front
+	const ENDINGS = {
+		ending_saint: {
+			id: "ending_saint",
+			title: "Saint of Ashes",
+			text: "You spent yourself saving the broken. Your name is a whispered prayer in the ruins. Mercy cost you much, but the world remembers kindness.",
+			criteria: state => state.morality >= 45
+		},
+		ending_tyrant: {
+			id: "ending_tyrant",
+			title: "Tyrant of the Block",
+			text: "You seized control and made the block obey. Order was carved from fear. Survivors live, but flinch when the floorboards creak.",
+			criteria: state => state.morality <= -45 && state.trauma < 80
+		},
+		ending_ghost: {
+			id: "ending_ghost",
+			title: "The Ghost in the Vents",
+			text: "You vanished between walls and rooftops. A rumor. A breath on the back of the neck. Stashes filled; names crossed out.",
+			criteria: state => state.flags.stalker === true
+		},
+		ending_manipulator: {
+			id: "ending_manipulator",
+			title: "Smiling Knives",
+			text: "Words were your blade. Debts, favors, secrets—your web held the city. No one can point to a weapon, only to your smile.",
+			criteria: state => state.flags.manipulator === true
+		},
+		ending_lone_survivor: {
+			id: "ending_lone_survivor",
+			title: "Alone On Purpose",
+			text: "You chose yourself over the many. Food lasted. Noise stayed low. In the quiet, you learned the shape of your own shadow.",
+			criteria: state => state.flags.loneWolf === true
+		},
+		ending_bloomborne: {
+			id: "ending_bloomborne",
+			title: "Bloomborne",
+			text: "You listened to the whisper until it answered back. Filaments under skin, light in the throat. You became the song the city hums.",
+			criteria: state => state.flags.bloomChoice === true
+		}
+	};
+
+	// Core scene graph. Limit to 4 choices per scene.
+	const SCENES = {
+		intro: {
+			text: "A low, desperate pounding rattles your door. A voice—Alex from next door—pleads through the wood: 'Please. Please, I got bit. I don't know what to do.' The hall reeks of disinfectant and wet mold. Outside, distant sirens tangle with the Bloom's static hush.",
+			choices: [
+				{ id: "help_alex", text: "Unbolt the door and help Alex inside", effects: { morality: +6, stress: +4 }, goTo: "alex_inside" },
+				{ id: "stay_silent", text: "Stay silent and hold your breath", effects: { morality: -4, stress: +2 }, goTo: "silence_wait" },
+				{ id: "probe", text: "Talk through the door—test what he admits", effects: { }, goTo: "interrogate_alex" },
+				{ id: "window_escape", text: "Climb out the window to the fire escape", effects: { stress: +6 }, goTo: "alley_drop" }
+			]
+		},
+
+		alex_inside: {
+			text: "Alex stumbles in. The bite is a crescent of purpled teeth. He's shaking, eyes glass-bright. 'Don't let me turn.'",
+			onEnter: s => { s.flags.metAlex = true; },
+			choices: [
+				{ id: "treat", text: "Clean and dress the wound; keep him calm", effects: { trauma: +5 }, goTo: "treat_wound" },
+				{ id: "bind", text: "Tie him to a chair 'for safety'", effects: { morality: -2 }, goTo: "bind_alex" },
+				{ id: "exploit", text: "Promise help if he signs over supplies", effects: { }, goTo: "exploit_alex" },
+				{ id: "mercy_kill", text: "Whisper an apology and end it quickly", effects: { morality: -12, trauma: +12 }, goTo: "mercy_kill_alex" }
+			]
+		},
+
+		silence_wait: {
+			text: "The pounding fades. Steps drag down the stairs. You count to one hundred before your lungs ask for air.",
+			choices: [
+				{ id: "follow", text: "Shadow him at a distance", effects: { }, goTo: "stalker_tail" },
+				{ id: "barricade", text: "Reinforce the door and take stock", effects: { stress: -4 }, goTo: "room_inventory" },
+				{ id: "call_out_late", text: "Call out—too late—and hear nothing", effects: { morality: -1 }, goTo: "room_inventory" },
+				{ id: "window_exit", text: "Slip out the window after him", effects: { }, goTo: "alley_drop" }
+			]
+		},
+
+		interrogate_alex: {
+			text: "'What happened?' you ask. Through the door Alex sobs about a stairwell ambush and a nest that sings under the maintenance lights.",
+			choices: [
+				{ id: "negotiate", text: "Offer help in exchange for his keys", effects: { }, goTo: "exploit_alex_from_door" },
+				{ id: "warn_off", text: "Tell him to leave before others hear", effects: { morality: -3 }, goTo: "silence_wait" },
+				{ id: "let_in", text: "Open up after all", effects: { morality: +3 }, goTo: "alex_inside" },
+				{ id: "record", text: "Record his confession for leverage later", effects: { }, goTo: "room_inventory", after: s => { s.flags.manipulator = true; } }
+			]
+		},
+
+		alley_drop: {
+			text: "You lower yourself to the fire escape. A rung slick with algae slides. You land hard in the alley; the Bloom's filaments shimmer in puddles.",
+			choices: [
+				{ id: "scavenge", text: "Scavenge the dumpsters", effects: { }, goTo: "find_cache" },
+				{ id: "leave_city", text: "Head toward the river alone", effects: { }, goTo: "lone_walk" },
+				{ id: "listen", text: "Listen to the distant hum—the Bloom's song", effects: { }, goTo: "bloom_listen" },
+				{ id: "circle_back", text: "Circle back to the lobby entrance", effects: { }, goTo: "lobby_crossroads" }
+			]
+		},
+
+		treat_wound: {
+			text: "You boil water, clean the bite, keep Alex talking. He laughs once—thin—and thanks you. Fever climbs.",
+			choices: [
+				{ id: "stay_with", text: "Stay with him through the night", effects: { morality: +4, stress: +3 }, goTo: "care_night" },
+				{ id: "seek_help", text: "Go find antibiotics at the pharmacy", effects: { }, goTo: "pharmacy_run" },
+				{ id: "plan_escape", text: "Plan evacuation for both of you", effects: { }, goTo: "evac_plan" },
+				{ id: "test_light", text: "Test the wound under the desk lamp's pulse", effects: { }, goTo: "bloom_test" }
+			]
+		},
+
+		bind_alex: {
+			text: "Rope bites his wrists. 'Just until we're sure,' you say. His eyes don't leave your hands.",
+			choices: [
+				{ id: "comfort", text: "Offer water and a story", effects: { morality: +1 }, goTo: "treat_wound" },
+				{ id: "interrogate", text: "Ask about his supplies and contacts", effects: { }, goTo: "exploit_alex" },
+				{ id: "threaten", text: "Remind him who has the knife", effects: { morality: -5, trauma: +2 }, goTo: "extract_tribute" },
+				{ id: "leave_bound", text: "Leave him and go loot", effects: { morality: -6 }, goTo: "find_cache" }
+			]
+		},
+
+		exploit_alex: {
+			text: "Alex has pantry keys, generator fuel, neighbors who trust him. He'll trade anything for hope.",
+			choices: [
+				{ id: "paper_sign", text: "Make him sign an IOU for half his stash", effects: { }, goTo: "paper_signed", after: s => { s.flags.manipulator = true; } },
+				{ id: "lie_cure", text: "Lie about a cure to secure obedience", effects: { morality: -8 }, goTo: "paper_signed", after: s => { s.flags.manipulator = true; } },
+				{ id: "relent", text: "Sigh and help without strings", effects: { morality: +6 }, goTo: "treat_wound" },
+				{ id: "sell_out", text: "Call the Purifiers and sell his location", effects: { morality: -10, trauma: +4 }, goTo: "route_purifiers", after: s => { s.flags.ruthless = true; } }
+			]
+		},
+
+		exploit_alex_from_door: {
+			text: "Through the wood you barter. He slides keys under the gap, hands trembling.",
+			choices: [
+				{ id: "take_keys", text: "Take the keys and send him away", effects: { morality: -6 }, goTo: "room_inventory", after: s => { s.flags.manipulator = true; } },
+				{ id: "open_after", text: "Open the door now that you hold leverage", effects: { }, goTo: "alex_inside" },
+				{ id: "keep_recording", text: "Keep recording every promise", effects: { }, goTo: "room_inventory", after: s => { s.flags.manipulator = true; } },
+				{ id: "apologize", text: "Apologize and refuse the trade", effects: { morality: +2 }, goTo: "silence_wait" }
+			]
+		},
+
+		mercy_kill_alex: {
+			text: "You do not miss. The room rings. The Bloom hum answers from the walls like distant rain.",
+			choices: [
+				{ id: "wipe_blade", text: "Wipe the blade and breathe", effects: { }, goTo: "room_inventory" },
+				{ id: "leave_now", text: "Leave before the neighbors come", effects: { }, goTo: "alley_drop" },
+				{ id: "sit", text: "Sit with him until the room stops spinning", effects: { trauma: +6 }, goTo: "room_inventory" },
+				{ id: "call_purifiers", text: "Call the Purifiers to claim the bounty", effects: { morality: -6 }, goTo: "route_purifiers" }
+			]
+		},
+
+		stalker_tail: {
+			text: "You move like a rumor. Alex limps toward the lobby, stopping to cough pink. He doesn't see you in the stairwell mirror.",
+			onEnter: s => { s.flags.stalker = true; },
+			choices: [
+				{ id: "shadow_more", text: "Shadow him to the street", effects: { }, goTo: "lobby_crossroads" },
+				{ id: "pick_pocket", text: "Lift his wallet on the landing", effects: { morality: -2 }, goTo: "room_inventory" },
+				{ id: "mark_route", text: "Note the Bloom clusters he avoids", effects: { }, goTo: "bloom_listen" },
+				{ id: "abort", text: "Return home, unheard", effects: { }, goTo: "room_inventory" }
+			]
+		},
+
+		find_cache: {
+			text: "Behind a loose brick you find a cache: bandages, two protein bars, a strange tuning fork etched with circles.",
+			choices: [
+				{ id: "take_all", text: "Take everything and move on", effects: { stress: -2 }, goTo: "lobby_crossroads" },
+				{ id: "leave_some", text: "Leave one bar for whoever comes next", effects: { morality: +2 }, goTo: "lobby_crossroads" },
+				{ id: "study_fork", text: "Strike the fork and listen to the walls", effects: { }, goTo: "bloom_listen" },
+				{ id: "stash", text: "Create a new stash elsewhere", effects: { }, goTo: "lone_walk", after: s => { s.flags.loneWolf = true; } }
+			]
+		},
+
+		bloom_test: {
+			text: "Under pulsing light the wound's veins contract, then reach. The Bloom hates some frequencies—and loves others.",
+			choices: [
+				{ id: "note_science", text: "Record frequencies that repel it", effects: { }, goTo: "room_inventory", after: s => { s.flags.bloomInsight = true; } },
+				{ id: "note_ecstasy", text: "Record frequencies that make it sing", effects: { }, goTo: "room_inventory", after: s => { s.flags.bloomChoice = true; } },
+				{ id: "do_nothing", text: "Turn off the light and pretend you saw nothing", effects: { }, goTo: "room_inventory" },
+				{ id: "panic", text: "Panic and step away", effects: { stress: +4 }, goTo: "room_inventory" }
+			]
+		},
+
+		bloom_listen: {
+			text: "You press the tuning fork to the railing. In the metal, a chord blooms—low, tender, hungry.",
+			choices: [
+				{ id: "resist", text: "Resist the harmony; memorize its shape", effects: { }, goTo: "lobby_crossroads", after: s => { s.flags.bloomInsight = true; } },
+				{ id: "answer", text: "Hum back until your teeth vibrate", effects: { trauma: -4 }, goTo: "finale_bridge", after: s => { s.flags.bloomChoice = true; } },
+				{ id: "smash", text: "Smash the fork and move on", effects: { }, goTo: "lobby_crossroads" },
+				{ id: "keep", text: "Pocket the fork for later", effects: { }, goTo: "lobby_crossroads" }
+			]
+		},
+
+		lobby_crossroads: {
+			text: "In the lobby: a barricaded door to the street, a pharmacy sign across the avenue, and Purifier graffiti: WE BURN WHAT SINGS.",
+			choices: [
+				{ id: "pharmacy", text: "Dash to the pharmacy for meds", effects: { }, goTo: "pharmacy_run" },
+				{ id: "purifiers", text: "Approach the Purifier checkpoint", effects: { }, goTo: "route_purifiers" },
+				{ id: "back_upstairs", text: "Return upstairs to Alex", effects: { }, goTo: "alex_inside" },
+				{ id: "river", text: "Head toward the river alone", effects: { }, goTo: "lone_walk", after: s => { s.flags.loneWolf = true; } }
+			]
+		},
+
+		pharmacy_run: {
+			text: "Shadows crowd the aisles. You grab antibiotics and gauze. Something rustles above the ceiling tiles.",
+			choices: [
+				{ id: "sneak", text: "Sneak out the back with what you can carry", effects: { stress: +2 }, goTo: "finale_bridge" },
+				{ id: "help_stranger", text: "A stranger hisses for help from behind a shelf—help them", effects: { morality: +5 }, goTo: "finale_bridge" },
+				{ id: "bait", text: "Toss a bottle to lure the nest away and bolt", effects: { }, goTo: "finale_bridge" },
+				{ id: "torch", text: "Set the ceiling on fire and run", effects: { morality: -6, trauma: +3 }, goTo: "finale_bridge", after: s => { s.flags.ruthless = true; } }
+			]
+		},
+
+		route_purifiers: {
+			text: "Red armbands and welded steel. A loudspeaker cracks: 'Declare yourself.'",
+			choices: [
+				{ id: "volunteer", text: "Volunteer intel on Bloom nests to gain favor", effects: { morality: -2 }, goTo: "finale_bridge", after: s => { s.flags.manipulator = true; } },
+				{ id: "trade", text: "Trade meds for access", effects: { }, goTo: "finale_bridge" },
+				{ id: "double_cross", text: "Feed them Alex's address and walk away", effects: { morality: -10 }, goTo: "finale_bridge", after: s => { s.flags.ruthless = true; s.flags.manipulator = true; } },
+				{ id: "withdraw", text: "Back away before they mark you", effects: { }, goTo: "finale_bridge" }
+			]
+		},
+
+		lone_walk: {
+			text: "Alone, the city is a map of risks you can carry in your head. No promises. No witnesses.",
+			onEnter: s => { s.flags.loneWolf = true; },
+			choices: [
+				{ id: "keep_moving", text: "Keep moving toward the water", effects: { }, goTo: "finale_bridge" },
+				{ id: "return", text: "Turn back one last time", effects: { }, goTo: "finale_bridge" },
+				{ id: "stash_more", text: "Make hidden stashes along the way", effects: { }, goTo: "finale_bridge" },
+				{ id: "follow_song", text: "Follow the song only you hear", effects: { }, goTo: "bloom_listen" }
+			]
+		},
+
+		paper_signed: {
+			text: "The paper is a promise with teeth. Alex signs with a shaking hand.",
+			choices: [
+				{ id: "cash_in", text: "Collect now and leave him to fate", effects: { morality: -6 }, goTo: "finale_bridge" },
+				{ id: "change_heart", text: "Tear it up and actually help", effects: { morality: +5 }, goTo: "treat_wound" },
+				{ id: "leverage", text: "Use it to bend the block to your will", effects: { }, goTo: "finale_bridge", after: s => { s.flags.manipulator = true; } },
+				{ id: "sell_purifiers", text: "Sell the debt to the Purifiers", effects: { morality: -8 }, goTo: "route_purifiers", after: s => { s.flags.manipulator = true; } }
+			]
+		},
+
+		evac_plan: {
+			text: "You map rooftops and alleys. With luck you and Alex can reach the ferry by dusk.",
+			choices: [
+				{ id: "depart_now", text: "Depart now while streets are thin", effects: { }, goTo: "finale_bridge" },
+				{ id: "wait", text: "Wait for night and try in the dark", effects: { stress: +2 }, goTo: "finale_bridge" },
+				{ id: "abandon", text: "Leave him sleeping and travel faster", effects: { morality: -7 }, goTo: "finale_bridge", after: s => { s.flags.loneWolf = true; } },
+				{ id: "call_help", text: "Radio anyone who still answers", effects: { }, goTo: "finale_bridge" }
+			]
+		},
+
+		finale_bridge: {
+			text: "Hours later, choices have a shape. The city listens. The Bloom hums its one long note.",
+			choices: [
+				{ id: "accept_fate", text: "Face what you've become", effects: { }, goTo: "THE_END" },
+				{ id: "one_more_good", text: "Do one more good deed on the way", effects: { morality: +2 }, goTo: "THE_END" },
+				{ id: "one_more_terrible", text: "Do one more terrible thing to feel in control", effects: { morality: -4 }, goTo: "THE_END" },
+				{ id: "listen_song", text: "Listen again to the song under everything", effects: { }, goTo: "THE_END", after: s => { if (!s.flags.bloomChoice && s.flags.bloomInsight) s.flags.bloomChoice = true; } }
+			]
+		}
+	};
+
+	class ConsequenceGame {
+		constructor() {
+			this.state = this.createInitialState();
+			this.ui = this.cacheUi();
+			this.bindUi();
+			this.renderStatus();
+			this.showSceneContainer(true);
+			this.goTo("intro");
+		}
+
+		createInitialState() {
+			return {
+				day: 0,
+				hour: 8,
+				morality: 0, // -100..100
+				trauma: 10, // 0..100
+				stress: 10, // 0..100
+				inventory: [],
+				flags: {},
+				currentSceneId: "intro",
+				eventLog: []
+			};
+		}
+
+		cacheUi() {
+			return {
+				container: document.getElementById("scene-container"),
+				text: document.getElementById("scene-text"),
+				choices: document.getElementById("choices"),
+				stats: document.getElementById("stats"),
+				inventory: document.getElementById("inventory"),
+				log: document.getElementById("log"),
+				saveBtn: document.getElementById("save-btn"),
+				loadBtn: document.getElementById("load-btn"),
+				restartBtn: document.getElementById("restart-btn")
+			};
+		}
+
+		bindUi() {
+			this.ui.saveBtn?.addEventListener("click", () => this.save());
+			this.ui.loadBtn?.addEventListener("click", () => this.load());
+			this.ui.restartBtn?.addEventListener("click", () => this.restart());
+		}
+
+		showSceneContainer(show) {
+			if (!this.ui.container) return;
+			this.ui.container.style.display = show ? "block" : "none";
+		}
+
+		renderStatus() {
+			if (!this.ui.stats) return;
+			const time = createElement("div", { class: "status-time" }, `Day ${this.state.day}, ${String(this.state.hour).padStart(2, "0")}:00`);
+			const moralityClass = this.state.morality > 15 ? "morality-good" : this.state.morality < -15 ? "morality-bad" : "morality-neutral";
+			const morality = createElement("span", { class: `status-pill ${moralityClass}`, title: "Your moral drift" }, `Morality ${this.state.morality}`);
+			const traumaClass = this.state.trauma > 66 ? "trauma-high" : this.state.trauma > 33 ? "trauma-medium" : "trauma-low";
+			const trauma = createElement("span", { class: `status-pill ${traumaClass}`, title: "Trauma" }, `Trauma ${this.state.trauma}`);
+			const stressClass = this.state.stress > 66 ? "stress-high" : this.state.stress > 33 ? "stress-medium" : "stress-low";
+			const stress = createElement("span", { class: `status-pill ${stressClass}`, title: "Stress" }, `Stress ${this.state.stress}`);
+			this.ui.stats.innerHTML = "";
+			this.ui.stats.appendChild(createElement("div", { class: "status-bar" },
+				time,
+				createElement("div", { class: "status-indicators" }, morality, trauma, stress)
+			));
+		}
+
+		advanceTime(hours) {
+			let total = this.state.hour + (hours || 1);
+			while (total >= 24) { total -= 24; this.state.day += 1; }
+			this.state.hour = total;
+			this.renderStatus();
+		}
+
+		goTo(sceneId) {
+			if (sceneId === "THE_END") {
+				return this.conclude();
+			}
+			this.state.currentSceneId = sceneId;
+			const scene = SCENES[sceneId];
+			if (!scene) {
+				this.writeLog(`Missing scene '${sceneId}'`, "world_event");
+				return;
+			}
+			if (typeof scene.onEnter === "function") scene.onEnter(this.state);
+			this.renderScene(scene);
+			this.renderStatus();
+		}
+
+		renderScene(scene) {
+			this.ui.text.textContent = scene.text;
+			this.ui.text.classList.add("fade-in");
+			this.ui.choices.innerHTML = "";
+			(scene.choices || []).slice(0, 4).forEach(choice => {
+				const button = createElement("button", { class: "choice-button" }, choice.text);
+				button.addEventListener("click", () => {
+					this.selectChoice(choice, scene);
+				});
+				this.ui.choices.appendChild(button);
+			});
+		}
+
+		selectChoice(choice, scene) {
+			// Apply effects
+			this.applyEffects(choice.effects || {});
+			if (typeof choice.after === "function") choice.after(this.state);
+			this.advanceTime(1);
+			this.goTo(choice.goTo);
+		}
+
+		applyEffects(effects) {
+			if (effects.morality) this.state.morality = clamp(this.state.morality + effects.morality, -100, 100);
+			if (effects.trauma) this.state.trauma = clamp(this.state.trauma + effects.trauma, 0, 100);
+			if (effects.stress) this.state.stress = clamp(this.state.stress + effects.stress, 0, 100);
+			const parts = [];
+			Object.entries(effects).forEach(([k, v]) => { if (v) parts.push(`${k} ${v >= 0 ? "+" : ""}${v}`); });
+			if (parts.length) this.writeLog(parts.join(", "), "consequence");
+		}
+
+		conclude() {
+			// Determine best-fitting ending based on criteria order
+			const entries = Object.values(ENDINGS);
+			const matched = entries.find(e => e.criteria(this.state));
+			const ending = matched || ENDINGS.ending_lone_survivor; // default fallback
+			this.renderEnding(ending);
+		}
+
+		renderEnding(ending) {
+			this.ui.text.textContent = `${ending.title}\n\n${ending.text}`;
+			this.ui.choices.innerHTML = "";
+			const restart = createElement("button", { class: "choice-button" }, "Restart");
+			restart.addEventListener("click", () => this.restart());
+			const save = createElement("button", { class: "choice-button" }, "Save Ending");
+			save.addEventListener("click", () => this.save());
+			this.ui.choices.appendChild(restart);
+			this.ui.choices.appendChild(save);
+			this.writeLog(`Reached: ${ending.title}`, "world_event");
+		}
+
+		writeLog(message, cssClass) {
+			this.state.eventLog.push({ t: Date.now(), message, cssClass });
+			if (!this.ui.log) return;
+			const row = createElement("div", { class: `event-log-entry ${cssClass || ""}` }, message);
+			this.ui.log.appendChild(row);
+			this.ui.log.scrollTop = this.ui.log.scrollHeight;
+		}
+
+		save() {
+			const data = JSON.stringify(this.state);
+			localStorage.setItem(STORAGE_KEY, data);
+			this.writeLog("Game saved", "discovery");
+		}
+
+		load() {
+			const data = localStorage.getItem(STORAGE_KEY);
+			if (!data) {
+				this.writeLog("No save found", "trauma");
+				return;
+			}
+			try {
+				const obj = JSON.parse(data);
+				this.state = Object.assign(this.createInitialState(), obj);
+				this.renderStatus();
+				if (this.state.currentSceneId && SCENES[this.state.currentSceneId]) this.goTo(this.state.currentSceneId);
+				else this.goTo("intro");
+				this.writeLog("Game loaded", "discovery");
+			} catch (err) {
+				console.error(err);
+				this.writeLog("Failed to load save", "trauma");
+			}
+		}
+
+		restart() {
+			this.state = this.createInitialState();
+			if (this.ui.log) this.ui.log.innerHTML = "";
+			this.renderStatus();
+			this.goTo("intro");
+			this.writeLog("New run started", "world_event");
+		}
+	}
+
+	// Expose globally for HTML bootstrap
+	window.ConsequenceGame = ConsequenceGame;
+})();


### PR DESCRIPTION
Refactor the game's narrative engine to support branching storylines and multiple endings, addressing previous structural and coherence issues.

The original `MYSTORY.JAVASCRIPT` was unstructured, leading to a confusing narrative and limited player agency. This PR introduces a new `script_5MB_FIXED.js` with an "endings-first" design, enabling diverse player paths (e.g., saint, tyrant, manipulator) and a maximum of 4 choices per scene for clarity. It also separates the time UI from the main story text and adds save/load/restart functionality.

---
<a href="https://cursor.com/background-agent?bcId=bc-3af0367a-2eed-4729-9ac4-0f136392735c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3af0367a-2eed-4729-9ac4-0f136392735c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

